### PR TITLE
Usability improvements

### DIFF
--- a/addons/project_file_search/search.gd
+++ b/addons/project_file_search/search.gd
@@ -40,7 +40,7 @@ func _input(event: InputEvent) -> void:
 		_current_panel = _SEARCH_SCENE.instantiate()
 		_current_panel.open_file.connect(_open_file)
 		add_child(_current_panel)
-		_current_panel.popup_centered()
+		_current_panel.popup_centered_ratio(0.5)
 
 func _open_file(path: String) -> void:
 	var ei := get_editor_interface()
@@ -53,7 +53,9 @@ func _open_file(path: String) -> void:
 		_current_panel = null
 
 func _bind_setting(default_value: Variant, info: Dictionary) -> void:
-	ProjectSettings.set(info["name"], default_value)
+	if !ProjectSettings.has_setting(info["name"]):
+		ProjectSettings.set(info["name"], default_value)
+	
 	ProjectSettings.add_property_info(info)
 
 func _clear_setting(name: String) -> void:

--- a/addons/project_file_search/search_panel.tscn
+++ b/addons/project_file_search/search_panel.tscn
@@ -1,12 +1,13 @@
 [gd_scene load_steps=2 format=3 uid="uid://b70ab8funi82r"]
 
-[ext_resource type="Script" path="res://addons/project_file_search/search_panel.gd" id="1_eqmk8"]
+[ext_resource type="Script" uid="uid://bsb8ncgmvly7h" path="res://addons/project_file_search/search_panel.gd" id="1_eqmk8"]
 
 [node name="SearchPanel" type="PopupPanel"]
 initial_position = 1
 size = Vector2i(640, 480)
 visible = true
 transient_to_focused = true
+min_size = Vector2i(640, 480)
 script = ExtResource("1_eqmk8")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]


### PR DESCRIPTION
Don't overwrite settings with default values every time you launch the project.
Open the window with a ratio of the main window (with a minimum of 640 by 480)